### PR TITLE
Fix domain schema max domain validation message

### DIFF
--- a/src/schemas/domain.schema.ts
+++ b/src/schemas/domain.schema.ts
@@ -147,7 +147,7 @@ export const DomainSchema = z.object({
       ])
     )
     .min(1, "At least one domain must be selected")
-    .max(3, "Maximum 5 domains allowed"),
+    .max(3, "Maximum 3 domains allowed"),
 });
 
 export type Domain = z.infer<typeof DomainSchema>;


### PR DESCRIPTION
## Summary
- clarify domain schema validation message to match three-domain limit

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68950e43eda08329afb128f821f6be22