### PR TITLE
fix: correct repository URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ src/
 
 ```bash
 # Clone the repository
-git clone https://github.com/Do-not-be-afraid-to-be-knonwn/Job-Seeker-AI-Assistant.git
+git clone https://github.com/Do-not-be-afraid-to-be-known/Job-Seeker-AI-Assistant.git
 cd Job-Seeker-AI-Assistant
 
 # Install dependencies
@@ -223,12 +223,11 @@ This project is licensed under the ISC License - see the [LICENSE](LICENSE) file
 
 ## 👨‍💻 Author
 
-**Matthew Hou** - [GitHub](https://github.com/Do-not-be-afraid-to-be-knonwn)
+**Matthew Hou** - [GitHub](https://github.com/Do-not-be-afraid-to-be-known)
 
 ## 🐛 Issues
 
-If you encounter any issues, please report them on the [GitHub Issues page](https://github.com/Do-not-be-afraid-to-be-knonwn/Job-Seeker-AI-Assistant/issues).
-
+If you encounter any issues, please report them on the [GitHub Issues page](https://github.com/Do-not-be-afraid-to-be-known/Job-Seeker-AI-Assistant/issues).
 ---
 
 **Built with ❤️ using LangChain, Ollama, and TypeScript**

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Do-not-be-afraid-to-be-knonwn/Job-Seeker-AI-Assistant"
+    "url": "git+https://github.com/Do-not-be-afraid-to-be-known/Job-Seeker-AI-Assistant"
   },
   "dependencies": {
     "@langchain/core": "^0.3.61",
@@ -34,9 +34,9 @@
   "author": "Matthew Hou",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/Do-not-be-afraid-to-be-knonwn/Job-Seeker-AI-Assistant"
+      "url": "https://github.com/Do-not-be-afraid-to-be-known/Job-Seeker-AI-Assistant"
   },
-  "homepage": "https://github.com/Do-not-be-afraid-to-be-knonwn/Job-Seeker-AI-Assistant#readme",
+  "homepage": "https://github.com/Do-not-be-afraid-to-be-known/Job-Seeker-AI-Assistant#readme",
   "devDependencies": {
     "@types/body-parser": "^1.19.6",
     "@types/cors": "^2.8.19",


### PR DESCRIPTION
## Summary
- fix typo in GitHub org name across README and package.json
- ensure project metadata points to the corrected repository

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run smoke` (fails: TS18048: 'level.result.text' is possibly 'undefined')

------
https://chatgpt.com/codex/tasks/task_e_689ab87868d48329aa92bc9402dad287