### PR TITLE
feat: add Gemini Flash-Lite client

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@langchain/core": "^0.3.61",
-    "@langchain/ollama": "^0.2.3",
+    "@google/generative-ai": "^0.3.0",
     "body-parser": "^2.2.0",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",


### PR DESCRIPTION
## Summary
- integrate Gemini Flash-Lite via Google Generative AI SDK with retry support and env-based config
- remove Ollama usage and swap to new Gemini API client with CLI fallback
- load environment variables using dotenv

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@google%2fgenerative-ai)
- `npm test` (fails: Error: no test specified)
- `npm run smoke` (fails: TS18048 'level.result.text' is possibly 'undefined')


------
https://chatgpt.com/codex/tasks/task_e_689ce15a7fb88329854477c5c0882e16