### PR TITLE
Use Gemini 2.5 Flash Lite as primary with Flash fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Job seekers waste countless hours reading through lengthy job descriptions on pl
 - **Four Core Extraction Chains**: Skills, Level, Domain, and Years of Experience extraction
 - **Performance-Optimized**: High-speed validation and processing systems
 - **Comprehensive Testing**: Real job posting data validation and performance monitoring
-- **Dual LLM Architecture**: Reliable extraction with Ollama (local) + Gemini (fallback)
+- **Dual LLM Architecture**: Gemini 2.5 Flash Lite primary with Gemini 2.5 Flash fallback for reliability
 
 ### 🔄 What's Next
 
@@ -34,7 +34,7 @@ Job seekers waste countless hours reading through lengthy job descriptions on pl
 
 ### Technical Features
 
-- **Dual LLM Architecture**: Ollama (local) + Gemini (fallback) for reliability
+- **Dual LLM Architecture**: Gemini 2.5 Flash Lite + Gemini 2.5 Flash for reliability
 - **Performance Monitoring**: Real-time chain performance tracking and metrics
 - **Validation System**: Comprehensive test validation with flexible matching
 - **Optimized Processing**: High-performance validation and caching systems
@@ -110,8 +110,7 @@ src/
 ### Prerequisites
 
 - Node.js (v16 or higher)
-- Ollama (for local LLM processing)
-- Gemini CLI (for fallback processing)
+- Gemini API access
 
 ### Setup
 
@@ -123,12 +122,6 @@ cd Job-Seeker-AI-Assistant
 # Install dependencies
 npm install
 
-# Install Ollama (if not already installed)
-# Visit: https://ollama.ai/
-
-# Pull the Mistral model for Ollama
-ollama pull mistral
-
 # Create .env file with your configuration
 cp env.example .env
 # Edit .env with your API keys and preferences
@@ -139,13 +132,9 @@ cp env.example .env
 Create a `.env` file in the root directory with the following variables:
 
 ```env
-# Ollama Configuration (Primary LLM)
-OLLAMA_MODEL=mistral
-OLLAMA_BASE_URL=http://localhost:11434
-OLLAMA_TEMPERATURE=0.7
-
-# Gemini Configuration (Fallback LLM)
-GEMINI_MODEL=gemini-2.5-flash
+# Gemini Configuration
+GEMINI_PRIMARY_MODEL=gemini-2.5-flash-lite
+GEMINI_FALLBACK_MODEL=gemini-2.5-flash
 GEMINI_API_KEY=your_gemini_api_key_here
 GEMINI_TEMPERATURE=0.7
 GEMINI_MAX_RETRIES=3
@@ -215,16 +204,15 @@ npm run test-setup
 
 - **Chain Performance**: Response times, token usage, success rates
 - **Validation Accuracy**: Test result matching and accuracy rates
-- **LLM Usage**: Ollama vs Gemini usage statistics
+- **LLM Usage**: primary vs fallback usage statistics
 
 ## 🔧 Configuration
 
 ### LLM Configuration
 
-- **Primary**: Ollama with Mistral model (local processing)
-- **Fallback**: Gemini API with gemini-2.5-flash model (cloud processing)
+- **Primary**: Gemini API with gemini-2.5-flash-lite model
+- **Fallback**: Gemini API with gemini-2.5-flash model
 - **Retries**: Built-in retry mechanism with fallback
-- **CLI Fallback**: Gemini CLI as additional fallback option
 
 ### Validation System
 
@@ -261,4 +249,4 @@ This project is licensed under the ISC License - see the [LICENSE](LICENSE) file
 
 ## If you encounter any issues, please report them on the [GitHub Issues page](https://github.com/Do-not-be-afraid-to-be-known/Job-Seeker-AI-Assistant/issues).
 
-**Built with ❤️ using LangChain, Ollama, and TypeScript**
+**Built with ❤️ using LangChain, Gemini, and TypeScript**


### PR DESCRIPTION
## Summary
- generalize Gemini client to support primary `gemini-2.5-flash-lite` model with `gemini-2.5-flash` fallback
- document dual Gemini setup and new environment variables

## Testing
- `npm test` (fails: Error: no test specified)
- `npx tsc -p tsconfig.json --noEmit` (fails: Property does not exist errors)


------
https://chatgpt.com/codex/tasks/task_e_689cefc2f5ac8329b2a60b416b4ddc36