### PR TITLE
feat: add user feedback endpoint

### DIFF
--- a/src/chrome-extension-template/background.js
+++ b/src/chrome-extension-template/background.js
@@ -32,6 +32,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       try {
         const response = await fetch("https://api.joblyzer.net/feedback", {
           method: "POST",
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),
         });
         if (!response.ok) {


### PR DESCRIPTION
## Summary
- add server endpoint to persist user feedback
- ensure background script sends feedback with JSON header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e2c4e2e8083299e0d3b366af5639b