### PR TITLE
test: verify feedback queue processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "commonjs",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "ts-node src/scripts/runExtractSkills.ts",
     "dev": "ts-node --watch src/scripts/runExtractSkills.ts",
     "smoke": "ts-node test/smoke/smokeTest.ts",
@@ -44,6 +44,10 @@
     "@types/body-parser": "^1.19.6",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/test/backgroundQueue.test.js
+++ b/test/backgroundQueue.test.js
@@ -1,0 +1,43 @@
+const path = require('path');
+const { loadBackgroundScript } = require('./chromeExtensionTestKit');
+
+describe('USER_FEEDBACK queue', () => {
+  test('grows and processes in order', async () => {
+    const { chrome, context } = loadBackgroundScript(
+      path.join(__dirname, '../src/chrome-extension-template/background.js')
+    );
+
+    const res1 = await chrome.runtime.sendMessage({
+      type: 'USER_FEEDBACK',
+      payload: { id: 1 },
+    });
+    const res2 = await chrome.runtime.sendMessage({
+      type: 'USER_FEEDBACK',
+      payload: { id: 2 },
+    });
+
+    expect(res1).toEqual({ success: true });
+    expect(res2).toEqual({ success: true });
+
+    const queueData = await new Promise((resolve) =>
+      chrome.storage.local.get(['feedbackQueue'], resolve)
+    );
+    expect(queueData.feedbackQueue).toHaveLength(2);
+    expect(queueData.feedbackQueue[0].payload.id).toBe(1);
+    expect(queueData.feedbackQueue[1].payload.id).toBe(2);
+
+    const processed = [];
+    context.fetch = async (_url, opts) => {
+      processed.push(JSON.parse(opts.body).id);
+      return { ok: true, json: async () => ({}) };
+    };
+
+    await context.processQueue();
+
+    expect(processed).toEqual([1, 2]);
+    const queueAfter = await new Promise((resolve) =>
+      chrome.storage.local.get(['feedbackQueue'], resolve)
+    );
+    expect(queueAfter.feedbackQueue).toHaveLength(0);
+  });
+});

--- a/test/chromeExtensionTestKit.js
+++ b/test/chromeExtensionTestKit.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+function loadBackgroundScript(backgroundPath) {
+  const listeners = [];
+  const storage = {};
+
+  const chrome = {
+    storage: {
+      local: {
+        get(keys, cb) {
+          const kArr = Array.isArray(keys) ? keys : [keys];
+          const result = {};
+          for (const k of kArr) {
+            result[k] = storage[k];
+          }
+          setTimeout(() => cb(result), 0);
+        },
+        set(items, cb) {
+          Object.assign(storage, items);
+          setTimeout(() => cb && cb(), 0);
+        },
+      },
+    },
+    runtime: {
+      onMessage: {
+        addListener(fn) {
+          listeners.push(fn);
+        },
+      },
+      sendMessage(message) {
+        return new Promise((resolve) => {
+          for (const listener of listeners) {
+            listener(message, {}, resolve);
+          }
+        });
+      },
+    },
+  };
+
+  const timers = [];
+  function setIntervalStub(fn, _ms) {
+    timers.push(fn);
+    return timers.length - 1;
+  }
+
+  const context = {
+    chrome,
+    console,
+    setInterval: setIntervalStub,
+    clearInterval: () => {},
+    fetch: async () => ({ ok: true, json: async () => ({}) }),
+  };
+  context.global = context;
+
+  const code = fs.readFileSync(backgroundPath, 'utf8');
+  vm.runInNewContext(code, context, { filename: backgroundPath });
+
+  return { chrome, context };
+}
+
+module.exports = { loadBackgroundScript };


### PR DESCRIPTION
## Summary
- add minimal Chrome extension test harness
- migrate USER_FEEDBACK queue test to Jest verifying sequential processing and success responses
- configure Jest as project test runner

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a69c5d1210832990a7d1779d837de8