### PR TITLE
Add feedback endpoint tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "commonjs",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "ts-node src/scripts/runExtractSkills.ts",
     "dev": "ts-node --watch src/scripts/runExtractSkills.ts",
     "smoke": "ts-node test/smoke/smokeTest.ts",
@@ -44,6 +44,9 @@
     "@types/body-parser": "^1.19.6",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4",
+    "ts-jest": "^29.1.1",
     "typescript": "^5.8.3"
   }
 }

--- a/server.ts
+++ b/server.ts
@@ -119,6 +119,10 @@ app.post("/feedback", async (req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Chain server running on http://localhost:${PORT}`);
-});
+if (process.env.NODE_ENV !== "test") {
+  app.listen(PORT, () => {
+    console.log(`Chain server running on http://localhost:${PORT}`);
+  });
+}
+
+export default app;

--- a/test/feedback.test.ts
+++ b/test/feedback.test.ts
@@ -1,0 +1,58 @@
+import fs from 'fs/promises';
+import path from 'path';
+import request from 'supertest';
+import { beforeEach, describe, expect, test } from '@jest/globals';
+import app from '../server';
+
+process.env.NODE_ENV = 'test';
+
+const feedbackFile = path.join(__dirname, '..', 'feedback.jsonl');
+
+async function readEntries() {
+  try {
+    const data = await fs.readFile(feedbackFile, 'utf8');
+    return data
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  } catch (err: any) {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  }
+}
+
+beforeEach(async () => {
+  await fs.rm(feedbackFile, { force: true });
+});
+
+describe('/feedback endpoint', () => {
+  test('accepts JSON and raw string bodies', async () => {
+    let res = await request(app).post('/feedback').send({ message: 'json body' });
+    expect(res.status).toBe(200);
+    let entries = await readEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].message).toBe('json body');
+
+    res = await request(app)
+      .post('/feedback')
+      .set('Content-Type', 'text/plain')
+      .send(JSON.stringify({ message: 'raw body' }));
+    expect(res.status).toBe(200);
+    entries = await readEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries[1].message).toBe('raw body');
+  });
+
+  test('returns 500 for invalid JSON', async () => {
+    const res = await request(app)
+      .post('/feedback')
+      .set('Content-Type', 'text/plain')
+      .send('{invalid json}');
+    expect(res.status).toBe(500);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBeDefined();
+    const entries = await readEntries();
+    expect(entries).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- run feedback endpoint tests with Jest
- configure ts-jest for TypeScript sources
- remove unused @types/supertest dependency

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a69c614de08329abc5e92b8d08fbc1