### PR TITLE
Add end-to-end feedback test

### DIFF
--- a/test/e2e.feedback.test.js
+++ b/test/e2e.feedback.test.js
@@ -1,0 +1,70 @@
+/** @jest-environment node */
+const path = require('path');
+const fs = require('fs/promises');
+const { spawn } = require('child_process');
+
+const FEEDBACK_QUEUE_KEY = 'feedbackQueue';
+const storage = { [FEEDBACK_QUEUE_KEY]: [] };
+
+global.chrome = {
+  storage: {
+    local: {
+      get: (_keys, cb) => cb({ [FEEDBACK_QUEUE_KEY]: storage[FEEDBACK_QUEUE_KEY] }),
+      set: (obj, cb) => {
+        storage[FEEDBACK_QUEUE_KEY] = obj[FEEDBACK_QUEUE_KEY];
+        cb();
+      }
+    }
+  },
+  runtime: { onMessage: { addListener: () => {} } },
+};
+
+describe('feedback end-to-end', () => {
+  let serverProc;
+  jest.setTimeout(20000);
+
+  beforeAll(async () => {
+    const feedbackPath = path.join(__dirname, '..', 'feedback.jsonl');
+    try { await fs.unlink(feedbackPath); } catch (_) {}
+
+    serverProc = spawn('npx', ['ts-node', 'server.ts'], {
+      cwd: path.join(__dirname, '..'),
+      env: { ...process.env, NODE_ENV: 'development' },
+    });
+    await new Promise((resolve, reject) => {
+      serverProc.stdout.on('data', data => {
+        if (data.toString().includes('Chain server running')) resolve();
+      });
+      serverProc.stderr.on('data', reject);
+      serverProc.on('error', reject);
+    });
+  });
+
+  afterAll(() => {
+    serverProc.kill();
+  });
+
+  test('records feedback in feedback.jsonl', async () => {
+    const { enqueueFeedback, processQueue } = require('../src/chrome-extension-template/background.js');
+
+    const realFetch = global.fetch;
+    global.fetch = async (url, options) => {
+      if (url === 'https://api.joblyzer.net/feedback') {
+        url = 'http://localhost:3000/feedback';
+      }
+      return await realFetch(url, options);
+    };
+
+    await enqueueFeedback({ jobId: '123', feedback: 'great job' });
+    await processQueue();
+
+    const feedbackPath = path.join(__dirname, '..', 'feedback.jsonl');
+    // wait a moment for file to be written
+    await new Promise(r => setTimeout(r, 100));
+    const content = await fs.readFile(feedbackPath, 'utf-8');
+    const lines = content.trim().split('\n');
+    const last = JSON.parse(lines[lines.length - 1]);
+    expect(last.jobId).toBe('123');
+    expect(last.feedback).toBe('great job');
+  });
+});


### PR DESCRIPTION
## Summary
- add an end-to-end Jest test that starts the local server, simulates feedback from the extension background script, and verifies `feedback.jsonl` is updated
- ensure the test runs the server in development mode with a longer timeout and preserves the original `fetch`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a69c6730e08329b69ead054dbb1958