### PR TITLE
feat: add auth buttons to extension sidebar

### DIFF
--- a/src/chrome-extension-template/contentScript.js
+++ b/src/chrome-extension-template/contentScript.js
@@ -58,6 +58,24 @@ const createSidebarStyles = () => {
     .job-ai-sidebar-close:hover {
       background: #1e40af;
     }
+    .job-ai-auth {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+      padding: 8px 18px;
+    }
+    .job-ai-auth-btn {
+      background: #2563eb;
+      color: #fff;
+      border: none;
+      border-radius: 6px;
+      padding: 6px 12px;
+      cursor: pointer;
+      font-size: 14px;
+    }
+    .job-ai-auth-btn:hover {
+      background: #1e40af;
+    }
     .job-ai-sidebar-content {
       padding: 24px 18px 24px 18px;
     }
@@ -181,6 +199,10 @@ const createSidebar = () => {
       <span>Job AI Assistant</span>
       <button class="job-ai-sidebar-close">&times;</button>
     </div>
+    <div class="job-ai-auth">
+      <button class="job-ai-auth-btn job-ai-login">Sign In</button>
+      <button class="job-ai-auth-btn job-ai-logout">Sign Out</button>
+    </div>
     <div class="job-ai-sidebar-content">
       <div class="job-ai-loading">Analyzing job posting...</div>
     </div>
@@ -188,6 +210,14 @@ const createSidebar = () => {
   const closeBtn = sidebar.querySelector(".job-ai-sidebar-close");
   closeBtn.addEventListener("click", () => {
     sidebar.classList.remove("open");
+  });
+  const loginBtn = sidebar.querySelector(".job-ai-login");
+  loginBtn.addEventListener("click", () => {
+    chrome.runtime.sendMessage({ type: "AUTH_LOGIN" });
+  });
+  const logoutBtn = sidebar.querySelector(".job-ai-logout");
+  logoutBtn.addEventListener("click", () => {
+    chrome.runtime.sendMessage({ type: "AUTH_LOGOUT" });
   });
   document.body.appendChild(sidebar);
   return sidebar;
@@ -379,5 +409,5 @@ document.addEventListener("click", async (event) => {
 
 // Export for testing purposes when running in Node environment
 if (typeof module !== "undefined") {
-  module.exports = { updateSidebarContent };
+  module.exports = { updateSidebarContent, createSidebar };
 }

--- a/src/chrome-extension-template/contentScript.test.js
+++ b/src/chrome-extension-template/contentScript.test.js
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 
 const { fireEvent } = require('@testing-library/dom');
-const { updateSidebarContent } = require('./contentScript');
+const { updateSidebarContent, createSidebar } = require('./contentScript');
 
 describe('feedback interactions', () => {
   let sendMessageMock;
@@ -49,6 +49,30 @@ describe('feedback interactions', () => {
     });
     expect(sendMessageMock).toHaveBeenCalledTimes(1);
     expect(textarea.value).toBe('');
+  });
+});
+
+describe('auth buttons', () => {
+  let sendMessageMock;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    sendMessageMock = jest.fn();
+    global.chrome = { runtime: { sendMessage: sendMessageMock } };
+  });
+
+  test('signin button sends AUTH_LOGIN', () => {
+    const sidebar = createSidebar();
+    const btn = sidebar.querySelector('.job-ai-login');
+    fireEvent.click(btn);
+    expect(sendMessageMock).toHaveBeenCalledWith({ type: 'AUTH_LOGIN' });
+  });
+
+  test('signout button sends AUTH_LOGOUT', () => {
+    const sidebar = createSidebar();
+    const btn = sidebar.querySelector('.job-ai-logout');
+    fireEvent.click(btn);
+    expect(sendMessageMock).toHaveBeenCalledWith({ type: 'AUTH_LOGOUT' });
   });
 });
 


### PR DESCRIPTION
## Summary
- add sign in/out buttons to extension sidebar with messaging to background
- style new auth controls
- test auth buttons send expected messages

## Testing
- `npm test` *(fails: jest: not found)*
- `npx jest --version` *(fails: 403 Forbidden accessing registry)*

------
https://chatgpt.com/codex/tasks/task_e_68af666f2d908329ae029a9f72403b69